### PR TITLE
Moved angular-mocks to devDependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,8 +21,10 @@
   ],
   "dependencies": {
     "angular": ">=1.2.18",
-    "angular-mocks": ">=1.2.18",
     "angular-validator": ">=0.2.3",
     "jquery": "~2.1.0"
+  },
+  "devDependencies": {
+    "angular-mocks": ">=1.2.18"
   }
 }


### PR DESCRIPTION
angular-mocks should be in "devDependencies",

Read more [here](http://stackoverflow.com/questions/19339227/bower-and-devdependencies-vs-dependencies)